### PR TITLE
Stop hybrid tenant whose config is in a sub-directory managed by jenkins lib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,6 +82,7 @@ timestamps {
 				currentBuild.description = currentBuild.description + " => failed"
 				throw any
 			} finally {
+				stopHybridTenant()
 				shDockerComposeCleanUp()
 
 				junit allowEmptyResults: true, testResults: 'build/test-results/**/*.xml'


### PR DESCRIPTION
Merge jenkins-lib PR https://bitbucket.org/abascloud/esdk-jenkins-lib/pull-requests/55/setup-hybrid-tenant-in-sub-directory-dont/diff first, in order to get this PR to work.