### PR TITLE
ESDK-1390 docker cleanup after nightly build trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 
 def version = ""
 String errorMessage = null
+String defaultErpVersion = "2017r4n16p02"
 
 timestamps {
 	ansiColor('xterm') {
@@ -10,7 +11,7 @@ timestamps {
 				properties([parameters([
 						string(name: 'ESDK_VERSION', defaultValue: '', description: 'Version of ESDK to use (if not same as project version, project version will be updated as well)'),
 						string(name: 'BUILD_USER_PARAM', defaultValue: 'anonymous', description: 'User who triggered the build implicitly (through a commit in another project)'),
-						string(name: 'ERP_VERSION', defaultValue: '2017r4n16p02', description: 'abas Essentials version')
+						string(name: 'ERP_VERSION', defaultValue: defaultErpVersion, description: 'abas Essentials version')
 				])
 				])
 				stage('Setup') {
@@ -88,12 +89,8 @@ timestamps {
 			} finally {
 				stopHybridTenant()
 				shDockerComposeCleanUp()
-				def causes = currentBuild.rawBuild.getCauses()
-				for (def cause in causes) {
-					println(cause)
-					if (cause instanceof hudson.triggers.TimerTrigger.TimerTriggerCause) {
-						shDocker("system prune -a -f")
-					}
+				if (params.ESDK_VERSION.trim() != defaultErpVersion) {
+					shDocker("system prune -a -f")
 				}
 
 				slackNotify(currentBuild.result, 'esdk-bot', currentBuild.description)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,9 @@ timestamps {
 			} finally {
 				stopHybridTenant()
 				shDockerComposeCleanUp()
+				if (BUILD_CAUSE_TIMERTRIGGER == true) {
+					shDocker("system prune -a -f")
+				}
 
 				slackNotify(currentBuild.result, 'esdk-bot', currentBuild.description)
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,8 +88,12 @@ timestamps {
 			} finally {
 				stopHybridTenant()
 				shDockerComposeCleanUp()
-				if (BUILD_CAUSE_TIMERTRIGGER == true) {
-					shDocker("system prune -a -f")
+				def causes = currentBuild.rawBuild.getCauses()
+				for (def cause in causes) {
+					println(cause)
+					if (cause instanceof hudson.triggers.TimerTrigger.TimerTriggerCause) {
+						shDocker("system prune -a -f")
+					}
 				}
 
 				slackNotify(currentBuild.result, 'esdk-bot', currentBuild.description)


### PR DESCRIPTION
If this does not work https://stackoverflow.com/questions/34195135/how-can-i-check-whether-the-build-is-triiggered-by-timer-or-by-the-user might have alternatives to the environment variable.

This works for sure:
`
def context = getContext(Run.class)
context.getCauses().each {
    println(it)
}
`

But I could not find the Timer Trigger Cause Class in the JavaDoc, it does not seem to be up-to-date or it might be from a plugin.