### PR TITLE
ESDK-1429 update timeout to 20 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ timestamps {
 	ansiColor('xterm') {
 		node {
 			try {
-				timeout(activity: true, time: 10) {
+				timeout(activity: true, time: 20) {
 					properties([parameters([
 							string(name: 'ESDK_VERSION', defaultValue: '', description: 'Version of ESDK to use (if not same as project version, project version will be updated as well)'),
 							string(name: 'BUILD_USER_PARAM', defaultValue: 'anonymous', description: 'User who triggered the build implicitly (through a commit in another project)'),


### PR DESCRIPTION
The activity parameter does not seem to work properly and builds are cancelled during varreorg even though there was log output less than 10 minutes ago.
As a workaround timeout is set to slightly more than the job usually takes to complete.