### PR TITLE
ESDK-1534 Remove the space character that is too much in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ timestamps {
 						}
 						gitSetUser()
 						prepareEnv()
-						rmDirInMavenLocal '​de/abas/esdk'
+						rmDirInMavenLocal 'de/abas/esdk'
 						currentBuild.description = "ERP version: ${params.ERP_VERSION}"
 						initGradleProps()
 					}


### PR DESCRIPTION
It propably leads to testing against an older version because the maven
local cache is not cleared the right way.