### PR TITLE
ESDK-2006 resolve release versions of ESDK via plugins.gradle.org

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,34 @@
 buildscript {
-	repositories {
-		mavenLocal()
-		maven {
-			credentials {
-				username nexusUser
-				password nexusPassword
+	if (version.endsWith("-SNAPSHOT")) {
+		repositories {
+			mavenLocal()
+			maven {
+				credentials {
+					username nexusUser
+					password nexusPassword
+				}
+				url esdkSnapshotURL
 			}
-			url esdkSnapshotURL
-		}
-		maven {
-			credentials {
-				username nexusUser
-				password nexusPassword
+			maven {
+				credentials {
+					username nexusUser
+					password nexusPassword
+				}
+				url esdkReleaseURL
 			}
-			url esdkReleaseURL
 		}
-	}
-	dependencies {
-		classpath "de.abas.esdk:gradlePlugin:$version"
+		dependencies {
+			classpath "de.abas.esdk:gradlePlugin:$version"
+		}
+	} else {
+		repositories {
+			maven {
+				url "https://plugins.gradle.org/m2/"
+			}
+		}
+		dependencies {
+			classpath "esdk:gradlePlugin:$version"
+		}
 	}
 }
 


### PR DESCRIPTION
This way we get feedback on whether the external plugin and it's dependencies can be resolved correctly.